### PR TITLE
Use user_agent instead of fake_useragent (+ bug fix)

### DIFF
--- a/Twper/Twper.py
+++ b/Twper/Twper.py
@@ -4,12 +4,14 @@ from coala_utils.decorators import generate_ordering
 import random
 import aiohttp
 import asyncio
-from fake_useragent import UserAgent
+from user_agent import generate_user_agent
 import requests
 from aiostream import stream
 
-ua = UserAgent()
-HEADERS_LIST = [ua.chrome, ua.google, ua['google chrome'], ua.firefox, ua.ff]
+HEADERS_LIST = [
+    generate_user_agent(navigator='firefox', device_type='desktop'),
+    generate_user_agent(navigator='chrome', device_type='desktop')
+]
 
 
 # For the most part this was shamelessly stolen from https://github.com/taspinar/twitterscraper
@@ -208,7 +210,7 @@ class Query(object):
                         if not tweets:
                             return [], None
                         return tweets, json_resp['min_position']
-                except (ConnectionError, aiohttp.client_exceptions):
+                except (ConnectionError, aiohttp.ClientError):
                     if retry > 0:
                         return await self.query_single_page(session, url, html_response=html_response, retry=retry-1)
                 return [], None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coala-utils~=0.5.0
 bs4
 lxml
-fake_useragent
+user_agent
 requests
 asyncio
 aiohttp

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt') as requirements:
 
 setup(
     name='Twper',
-    version='0.1.3',
+    version='0.1.4',
     description='An asynchronous twitter scraper',
     long_description=long_description,
     url='https://github.com/jungerm2/Twper',


### PR DESCRIPTION
While trying to use this package, I noticed that it would often not scrape any tweets at all. After digging around in the code I realized that the `fake_useragent` package is providing User-Agent strings for browser versions that are considered outdated by Twitter. When this happens, mobile Twitter is loaded instead, and the Tweets are not converted from HTML properly. 

Switching to the `user_agent` package ensures that the browser versions are up-to-date (or so it seems, I haven't seen any issues with it yet) and that the tweets are returned every time. The browsers aren't as diverse as those generated by `fake_useragent` though, so if there's another package that could be used, I'm open to using it instead.

I've also fixed the try/except in `query_single_page()` to catch `aiohttp.ClientError` rather than `aiohttp.client_exceptions`, which was throwing an error due to it not being an actual exception type.